### PR TITLE
AUT-213: include user-agent in all requests

### DIFF
--- a/src/test/scala/uk/gov/di/authentication/perftest/AuthenticationSimulation.scala
+++ b/src/test/scala/uk/gov/di/authentication/perftest/AuthenticationSimulation.scala
@@ -65,7 +65,7 @@ class AuthenticationSimulation extends Simulation {
           regex("""<input type="hidden" name="_csrf" value="(.*)"/>""")
             .saveAs("csrfToken")
         )
-        .header("User-Agent", "Chrome")
+        .header("User-Agent", Configuration.userAgent)
     ).pause(Configuration.pauseMin, Configuration.pauseMax)
   }
 
@@ -77,6 +77,7 @@ class AuthenticationSimulation extends Simulation {
       .check(
         status.is(200)
       )
+      .header("User-Agent", Configuration.userAgent)
   ).pause(Configuration.pauseMin, Configuration.pauseMax)
 
   private def reqEnterEmailPost() = exec(
@@ -85,6 +86,7 @@ class AuthenticationSimulation extends Simulation {
       .formParam("_csrf", "${csrfToken}")
       .formParam("email", Configuration.TEST_USER_EMAIL)
       .check(status.is(200))
+      .header("User-Agent", Configuration.userAgent)
   )
     .pause(Configuration.pauseMin, Configuration.pauseMax)
 
@@ -94,6 +96,7 @@ class AuthenticationSimulation extends Simulation {
       .formParam("_csrf", "${csrfToken}")
       .formParam("password", Configuration.TEST_USER_PASSWORD)
       .check(status.is(200))
+      .header("User-Agent", Configuration.userAgent)
   ).pause(Configuration.pauseMin, Configuration.pauseMax)
 
   private def reqEnterCodePost() = exec(
@@ -102,7 +105,7 @@ class AuthenticationSimulation extends Simulation {
       .formParam("_csrf", "${csrfToken}")
       .formParam("code", Configuration.TEST_USER_PHONE_CODE)
       .check(status.is(200))
-      .header("User-Agent", "Chrome")
+      .header("User-Agent", Configuration.userAgent)
   ).pause(Configuration.pauseMin, Configuration.pauseMax)
 
   private def reqAccountManagementLaunchGetRequest(): ChainBuilder = {
@@ -112,7 +115,7 @@ class AuthenticationSimulation extends Simulation {
         .check(
           status.is(200)
         )
-        .header("User-Agent", "Chrome")
+        .header("User-Agent", Configuration.userAgent)
     ).pause(Configuration.pauseMin, Configuration.pauseMax)
   }
 

--- a/src/test/scala/uk/gov/di/authentication/perftest/ConstantUsersSimulation.scala
+++ b/src/test/scala/uk/gov/di/authentication/perftest/ConstantUsersSimulation.scala
@@ -1,6 +1,10 @@
 package uk.gov.di.authentication.perftest
 
-import io.gatling.core.Predef.{closedInjectionProfileFactory, constantConcurrentUsers, rampConcurrentUsers}
+import io.gatling.core.Predef.{
+  closedInjectionProfileFactory,
+  constantConcurrentUsers,
+  rampConcurrentUsers
+}
 import uk.gov.di.authentication.perftest.support.{Configuration, Parameters}
 
 class ConstantUsersSimulation extends AuthenticationSimulation {

--- a/src/test/scala/uk/gov/di/authentication/perftest/support/Configuration.scala
+++ b/src/test/scala/uk/gov/di/authentication/perftest/support/Configuration.scala
@@ -84,4 +84,6 @@ object Configuration {
   val pauseMax: FiniteDuration = Parameters
     .doubleParameter("pauseBetweenRequestsInSecondsMax", 6)
     .toLong seconds
+
+  val userAgent: String = "Chrome"
 }


### PR DESCRIPTION
## What

Include user-agent in all requests.

## Why

WAF blocks when there is no user-agent.